### PR TITLE
fix null exception if column has no name

### DIFF
--- a/Sources/CsvReader.Excel/ExcelExtensions.cs
+++ b/Sources/CsvReader.Excel/ExcelExtensions.cs
@@ -155,7 +155,8 @@ namespace DataAccess
                 Column[] cs = new Column[columns.Length];                
                 for (int ic = 0; ic < columns.Length; ic++)
                 {
-                    string columnName = dict[0, columns[ic]].ToString(); ;
+                    // fix for empty column name
+                    string columnName = dict[0, columns[ic]] == null ? string.Empty : dict[0, columns[ic]].ToString(); ;
                     cs[ic] = new Column(columnName, count);
                 }
                 d.Columns = cs;


### PR DESCRIPTION
dict[0, columns[ic]] is null if column has no name
