### PR TITLE
New DataTableBuiler.ReadString() method

### DIFF
--- a/Sources/DataAccess/DataTableBuilder.cs
+++ b/Sources/DataAccess/DataTableBuilder.cs
@@ -84,7 +84,7 @@ namespace DataAccess
         /// </summary>
         /// <param name="builder">ignored</param>
         /// <param name="stream">input stream to read from</param>
-        /// <param name="delimiter">delimiter characeter to use for separatior</param>
+        /// <param name="delimiter">delimiter character to use for separatior</param>
         /// <returns>a new in-memory table</returns>
         public static MutableDataTable Read(this DataTableBuilder builder, TextReader stream, char delimiter)
         {
@@ -97,7 +97,24 @@ namespace DataAccess
             return Reader.Read(stream, delimiter);
         }
 
+        /// <summary>
+        /// Create a csv based on the text provided in a string
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="text">Text to process</param>
+        /// <param name="newLine">Newline character sequence. Defaults to Windows newline (\r\n)</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static MutableDataTable ReadFromString(this DataTableBuilder builder, string text, string newLine = "\r\n")
+        {
+            Debug.Assert(builder != null);
+            if (string.IsNullOrEmpty(text))
+            {
+                throw new ArgumentNullException("text");
+            }
 
+            return Reader.ReadString(text, newLine);
+        }
 
         /// <summary>
         /// Gets a mutable in-memory copy of the given data table.

--- a/Sources/DataAccess/Readers.cs
+++ b/Sources/DataAccess/Readers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace DataAccess
@@ -217,9 +218,21 @@ namespace DataAccess
             }   
         }
 
+        private static IList<string> ReadAllLines(string text, string newLine = "\r\n")
+        {
+            var lines = text.Split(new [] {newLine}, StringSplitOptions.RemoveEmptyEntries).ToList();
+            return lines;
+        }
+
         public static MutableDataTable Read(TextReader stream, char delimiter = '\0', string[] defaultColumns = null)
         {
             IList<string> lines = ReadAllLines(stream);
+            return ReadArray(lines, delimiter, false, defaultColumns);
+        }
+
+        public static MutableDataTable ReadString(string text, string newLine = "\r\n", char delimiter = '\0', string[] defaultColumns = null)
+        {
+            IList<string> lines = ReadAllLines(text, newLine);
             return ReadArray(lines, delimiter, false, defaultColumns);
         }
 

--- a/Sources/DataTableTests/DataTableTests.cs
+++ b/Sources/DataTableTests/DataTableTests.cs
@@ -85,6 +85,26 @@ namespace DataTableTests
 
             s.Position = 0; // verify stream is not disposed
             
-        }        
+        }
+
+        [Fact]
+        public void ReadFromString_ProperInputWithDefaultLineEndings_EvaluatesProperly()
+        {
+            string input = "ID,Name,Age\r\n1,John Smith,23\r\n2,Jane Jones,32";
+            var dt = DataTable.New.ReadFromString(input);
+            Assert.Equal(2, dt.Rows.Count());
+            Assert.Equal(3, dt.Columns.Count());
+            Assert.Equal("Name", dt.ColumnNames.ToList()[1]);
+        }
+
+        [Fact]
+        public void ReadFromString_ProperInputUnixLineEndings_EvaluatesProperly()
+        {
+            string input = "ID,Name,Age\n1,John Smith,23\n2,Jane Jones,32";
+            var dt = DataTable.New.ReadFromString(input, "\n");
+            Assert.Equal(2, dt.Rows.Count());
+            Assert.Equal(3, dt.Columns.Count());
+            Assert.Equal("Name", dt.ColumnNames.ToList()[1]);
+        }
     }
 }


### PR DESCRIPTION
Added a new method `ReadFromString` to `DataTableBuilder`. Allows for building a csv from a string. Optional param to set the newline characters (defaults to Windows style: `\r\n`. Also includes test of the end-to-end function.
