### PR TITLE
Add Serialization Attributes to DataTable, Column and Row classes

### DIFF
--- a/Sources/DataAccess/Column.cs
+++ b/Sources/DataAccess/Column.cs
@@ -1,20 +1,24 @@
 ﻿using System.Diagnostics;
+using System.Runtime.Serialization;
 
 namespace DataAccess {
 
     /// <summary>
     /// Column from an in-memory data table. Columns know their length and directly expose their values as a mutable array.
     /// </summary>
+    [DataContract]
     public class Column {
         
         /// <summary>
         /// Name of the column. Operations on column names are case-insensitive.
         /// </summary>
+        [DataMember(Order = 1)]
         public string Name { get; set; } 
 
         /// <summary>
         /// Values in this column. 
         /// </summary>
+        [DataMember(Order = 2)]
         public string[] Values { get; set; } 
         
         /// <summary>

--- a/Sources/DataAccess/DataTable.cs
+++ b/Sources/DataAccess/DataTable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text;
 using System.IO;
 using System.Diagnostics;
@@ -14,6 +15,7 @@ namespace DataAccess
     /// The table may be just read-only streaming over the rows, which is ideal for large files of millions of rows. 
     /// Or it may have loaded the entire table into memory, which can be ideal for mutation. 
     /// </summary>
+    [DataContract]
     public abstract class DataTable
     {
         /// <summary>
@@ -23,18 +25,21 @@ namespace DataAccess
         /// of how the table was created. 
         /// Name is primarily a debugging tool. You can't programaticaly rely on the name property unless you created the table.
         /// </summary>
+        [DataMember(Order = 1)]
         public string Name { get; set; }
 
         /// <summary>
         /// Name of columns in the table. Columns should be case-insensitive.
         /// If this is a mutable table, columns may be added, removed, or reordered.
         /// </summary>
+        [DataMember(Order = 2)]
         public abstract IEnumerable<string> ColumnNames { get; }
 
         /// <summary>
         /// Enumeration of rows in the table.
         /// Each row has a (possibly empty) value for each column.
         /// </summary>
+        [DataMember(Order = 3)]
         public abstract IEnumerable<Row> Rows { get; }
 
         /// <summary>

--- a/Sources/DataAccess/DataTable.csproj
+++ b/Sources/DataAccess/DataTable.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />

--- a/Sources/DataAccess/MutableDataTable.cs
+++ b/Sources/DataAccess/MutableDataTable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text;
 using System.IO;
 using System.Diagnostics;
@@ -20,12 +21,14 @@ namespace DataAccess
     /// Table is stored in column major format, so supports efficient column operations like add, remove, and reorder.
     /// Also exposes row enumeration. Table can be mutated through either row or column views.
     /// </summary>
+    [DataContract]
     public class MutableDataTable : DataTable {
 
         /// <summary>
         /// Return the set of columnns in this mutable table. 
         /// Column represent the direct storage and are mutable.
         /// </summary>
+        [DataMember(Order = 4)]
         public Column[] Columns { get; set; }
                
         /// <summary>

--- a/Sources/DataAccess/Row.cs
+++ b/Sources/DataAccess/Row.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System;
+using System.Runtime.Serialization;
 
 namespace DataAccess
 {
@@ -10,17 +11,20 @@ namespace DataAccess
     /// Represents a row within a <see cref="DataTable"/>
     /// The Row may or may not be mutable, depending on whether the table is mutable.
     /// </summary>
+    [DataContract]
     public abstract class Row
     {
         /// <summary>
         /// ordered collection of values for this row.
         /// The ordering matches the column ordering. 
         /// </summary>
+        [DataMember(Order = 1)]
         public abstract IList<string> Values { get ; }
 
         /// <summary>
         /// Column names for the table containing this row. This is a parallel collection to <see cref="Values"/>
         /// </summary>
+        [DataMember(Order = 2)]
         public abstract IEnumerable<string> ColumnNames { get; }
         
         // Write this single row to a CSV file

--- a/Sources/DataAccess/StreamingDataTable.cs
+++ b/Sources/DataAccess/StreamingDataTable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text;
 using System.IO;
 using System.Diagnostics;
@@ -11,6 +12,7 @@ namespace DataAccess
     // Use Stream instead of TextReader because it must be seekable.
     // This assumes exclusive access ot the stream. 
     // If another instance comes in, they'll trash each others position.
+    [DataContract]
     internal class StreamingDataTable : TextReaderDataTable
     {
         readonly Stream _input;
@@ -41,6 +43,7 @@ namespace DataAccess
             // Beware, disposing a StreamReader will get dispose the underlying stream.
             // So just nop here since we don't own the stream.
         }
+        [DataMember(Order = 2)]
         public override IEnumerable<string> ColumnNames
         {
             get
@@ -125,6 +128,7 @@ namespace DataAccess
     /// <summary>
     ///  Stream rows from a file. This is ideal for large read-only files.
     /// </summary>
+    [DataContract]
     internal abstract class TextReaderDataTable : DataTable
     {
         private string[] _names;
@@ -161,7 +165,8 @@ namespace DataAccess
         // called on reader from OpenText
         // Don't call dipose because that can close streams. 
         protected abstract void CloseText(TextReader reader);
-        
+
+        [DataMember(Order = 3)]
         public override IEnumerable<Row> Rows
         {
             get


### PR DESCRIPTION
Add `[DataContract]` and `[DataMember]` attributes to the different `DataTable`, `Column` and `Row` classes. This is to aid potential serialization of these objects using methods that rely on these attributes. A better attempt at achieving the same goal as #22.
