### PR TITLE
Overload KeepColumns, option for throwOnMissing

### DIFF
--- a/Sources/DataAccess/MutableDataTable.cs
+++ b/Sources/DataAccess/MutableDataTable.cs
@@ -28,28 +28,43 @@ namespace DataAccess
         /// Column represent the direct storage and are mutable.
         /// </summary>
         public Column[] Columns { get; set; }
-               
+
+        /// <summary>
+        /// Remove all columns except for the ones listed. 
+        /// Allows case insensitive matching.
+        /// Also reorders to match names.
+        /// </summary>
+        /// <param name="throwOnMissing">throw an exception if one of the columns is missing</param>
+        /// <param name="names">names of columns to match</param>
+        public void KeepColumns(bool throwOnMissing, params string[] names) {
+            int len = names.Length;
+            var keep = new List<Column>();
+            foreach (var name in names)
+            {
+                var col = GetColumn(name);
+                if (col == null)
+                {
+                    if (throwOnMissing)
+                    {
+                        throw new InvalidOperationException("No column named:" + name);
+                    }
+                    continue;
+                }
+                col.Name = name;
+                keep.Add(col);
+            }
+            this.Columns = keep.ToArray();
+        }
+
         /// <summary>
         /// Remove all columns except for the ones listed. 
         /// Allows case insensitive matching.
         /// Also reorders to match names.
         /// </summary>
         /// <param name="names">names of columns to match</param>
-        public void KeepColumns(params string[] names) {
-            int len = names.Length;
-            var keep = new Column[len];
-            for (int i = 0; i < len; i++) {
-                string name = names[i];
-                keep[i] = GetColumn(name);
-
-                if (keep[i] == null)
-                {
-                    throw new InvalidOperationException("No column named:" + name);
-                }
-                keep[i].Name = name; // Normalize names.
-                
-            }
-            this.Columns = keep;
+        public void KeepColumns(params string[] names)
+        {
+            KeepColumns(true, names);
         }
 
         private void VerifyColumnIndex(int position)

--- a/Sources/DataTableTests/MutableDataTableTests.cs
+++ b/Sources/DataTableTests/MutableDataTableTests.cs
@@ -111,6 +111,39 @@ Smith,Bob
 Jones,Fred
 ", dt);
         }
+        
+        [Fact]
+        public void KeepColumnsDoNotThrow()
+        {
+            MutableDataTable dt = GetTable();
+
+            dt.KeepColumns(false, "last", "first", "made up column name");
+
+            AnalyzeTests.AssertEquals(
+@"last,first
+Smith,Bob
+Jones,Fred
+", dt);
+        }
+
+        [Fact]
+        public void KeepColumnsThrowOnMissing()
+        {
+            MutableDataTable dt = GetTable();
+
+            bool wasErrorThrown = false;
+            try
+            {
+                dt.KeepColumns(true, "last", "first", "made up column name");
+            }
+            catch (InvalidOperationException)
+            {
+                wasErrorThrown = true;
+            }
+
+            Assert.True(wasErrorThrown);
+            // not testing contents of the table since we are assuming that an Exception was thrown
+        }
 
         [Fact]
         public void KeepColumnsRemove()


### PR DESCRIPTION
Overload the `MutableDataTable.KeepColumns()` method to allow the user to specify whether or not the function should throw an exception when a column in the list is missing.

The logic of the function is refactored to avoid setting the `Column` array until all columns are set, since it is not known ahead of time how many will match.

Supporting unit tests are also added.
