### PR TITLE
RowAs<T>(mappingDictionary)

### DIFF
--- a/Sources/DataAccess/CsvWriter.cs
+++ b/Sources/DataAccess/CsvWriter.cs
@@ -108,11 +108,12 @@ namespace DataAccess
             if (s == null)
                 return string.Empty;
 
-            if (s.IndexOf(',') >= 0)
-            {
-                return "\"" + s + "\"";
-            }
-            return s;
+//            if (s.IndexOf(',') >= 0)
+//            {
+//                return "\"" + s + "\"";
+//            }
+//            return s;
+            return string.Concat("\"", s.Replace("\"", "\"\""), "\"");
         }
 
         // Don't close the underlying stream, we don't own it. But we can flush it.

--- a/Sources/DataAccess/CsvWriter.cs
+++ b/Sources/DataAccess/CsvWriter.cs
@@ -108,12 +108,11 @@ namespace DataAccess
             if (s == null)
                 return string.Empty;
 
-//            if (s.IndexOf(',') >= 0)
-//            {
-//                return "\"" + s + "\"";
-//            }
-//            return s;
-            return string.Concat("\"", s.Replace("\"", "\"\""), "\"");
+            if (s.IndexOf(',') >= 0)
+            {
+                return "\"" + s + "\"";
+            }
+            return s;
         }
 
         // Don't close the underlying stream, we don't own it. But we can flush it.

--- a/Sources/DataAccess/DataTable.cs
+++ b/Sources/DataAccess/DataTable.cs
@@ -44,7 +44,7 @@ namespace DataAccess
         /// </summary>
         /// <typeparam name="T">Target object type to parse.</typeparam>
         /// <returns>enumeration of rows as strongly typed object</returns>
-        public virtual IEnumerable<T> RowsAs<T>() where T : class, new()
+        public virtual IEnumerable<T> RowsAs<T>(Dictionary<string, string> mappingDictionary = null) where T : class, new()
         {
             Func<Row, T> parser;
 
@@ -55,7 +55,7 @@ namespace DataAccess
                 parser = _parserFunc as Func<Row, T>;
                 if (parser == null)
                 {
-                    parser = GetParserFunction<T>();
+                    parser = GetParserFunction<T>(mappingDictionary);
                     _parserFunc = parser;
                 }
             }
@@ -82,9 +82,9 @@ namespace DataAccess
         /// This is useful if you need to cache the parser function
         /// </summary>
         /// <returns>the strongly typed object.</returns>
-        public Func<Row, T> GetParserFunction<T>()
+        public Func<Row, T> GetParserFunction<T>(Dictionary<string, string> mappingDictionary = null)
         {
-            return StrongTypeBinder.BuildMethod<T>(this.ColumnNames);
+            return StrongTypeBinder.BuildMethod<T>(this.ColumnNames, mappingDictionary);
         }
 
         // Cache the parser function. 


### PR DESCRIPTION
Example Usage:

Model:
```Javascript
public class sample
{
	public string InvoiceNumber { get; set; }
}
```

Implementation:
```Javascript
var mappings = new Dictionary<string, string>
{
     { "InvoiceNumber", "Invoice #" }
};

var sampleList = DataAccess.DataTable.New.ReadCsv("sample.csv").RowAs<sample>(mappings).ToList();
```