### PR TITLE
Fixed bug that caused reader.cs to read input incorrectly

### DIFF
--- a/Sources/DataAccess/Readers.cs
+++ b/Sources/DataAccess/Readers.cs
@@ -338,7 +338,7 @@ namespace DataAccess
         // Are we in the middle of a word? IE, should newlines count as part of the value?
         public bool ShouldNewlineBeContent()
         {
-            return _currentState == SplitState.EscapedWord;
+            return (_currentState == SplitState.EscapedWord) || (_currentState == SplitState.StartQuote);
         }
         public string[] DoneRow(bool trim)
         {

--- a/Sources/DataTableTests/ReaderTests.cs
+++ b/Sources/DataTableTests/ReaderTests.cs
@@ -355,5 +355,35 @@ Bob,Smith
                 File.Delete(tmpFile);
             }
         }
+
+        // Check to see if inputs with multiple Windows new line characters works
+        [Fact]
+        public void ReadWithMultipleNewLines()
+        {
+            // Beware of GIT checkouts and editors can replace newlines, so be explicit
+            string content = "abc,def, xyz\r\n" +
+                             "1,\"1a\r\n\r\n\r\n\r\n1b\", 1c\n" +
+                             "2, \"2a\n\n\n\n2b\",2c\n" +
+                             "3, 3ab, 3c";
+
+            var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
+
+            DataTable dt = DataTable.New.ReadLazy(stream);
+
+            var rows = dt.Rows.ToArray();
+            Assert.Equal(3, rows.Length);
+
+            Assert.Equal("1", rows[0].Values[0]);
+            Assert.Equal("1a\r\n\r\n\r\n\r\n1b", rows[0].Values[1]);
+            Assert.Equal("1c", rows[0].Values[2]);
+
+            Assert.Equal("2", rows[1].Values[0]);
+            Assert.Equal("2a\n\n\n\n2b", rows[1].Values[1]);
+            Assert.Equal("2c", rows[1].Values[2]);
+
+            Assert.Equal("3", rows[2].Values[0]);
+            Assert.Equal("3ab", rows[2].Values[1]);
+            Assert.Equal("3c", rows[2].Values[2]);
+        }
     }
 }


### PR DESCRIPTION
Fixed a bug where when a csv file contains an entry with multiple
Windows new line characters (\r\n) in succession, reader.cs would read
each \r\n as a separate entry instead of the whole string of them as one
entry.